### PR TITLE
These tests didn't do what you thought they did

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,8 +92,7 @@ let
     entropy = MbedTLS.Entropy()
 
     function entropy_func(buf)
-        rng = RandomDevice()
-        buf[:] = rand(rng, UInt8, length(buf))
+        buf[:] = rand(RandomDevice(), UInt8, length(buf))
         return Cint(length(buf))
     end
 
@@ -134,8 +133,7 @@ let
     entropy = MbedTLS.Entropy()
 
     function entropy_func(buf)
-        rng = RandomDevice()
-        buf[:] = rand(rng, UInt8, length(buf))
+        buf[:] = rand(RandomDevice(), UInt8, length(buf))
         return Cint(length(buf))
     end
 


### PR DESCRIPTION
The `rng` assignment inside the closure was actually reassigning the local `rng`,
which would then occaisionally segfault, because `RandomDevice` is immutable,
so there's nothing that actually rooted it to the device object.

Side note: Somebody should probably add assertions that the various things
we're trying to protect by rooting them in the context object are actually mutable.
However, I've spent too much time on this already so I'll leave that to somebody else ;).