### PR TITLE
Take out extra, unnecessary isopen checks

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -239,11 +239,7 @@ function which sends it to the underlying connection (`ctx.bio`).
 See `f_send` and `set_bio!` below.
 """
 function ssl_unsafe_write(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
-
-    Base.check_open(ctx.bio) # Throw error if `bio` is closed.
-
-    iswritable(ctx) ||
-    throw(ArgumentError("`unsafe_write` requires `iswritable(::SSLContext)`"))
+    ctx.close_notify_sent && throw(ArgumentError("`unsafe_write` requires `!ctx.close_notify_sent`"))
 
     nwritten = 0                                                                ;@🤖 "ssl_write ➡️  $nbytes"
     while nwritten < nbytes


### PR DESCRIPTION
We check `Base.check_open`, then `iswritable` checks `isopen`, and then we
check `isopen` again in `f_send` before we actually write. None of this is
particularly problematic except that if our bio isn't open in `Base.check_open`
then we get an `IOError`, but if `iswritable` fails, we get an `ArgumentError`.

By delaying the `isopen` check until `f_send`, I believe that will result in
a more predictable `MbedException` being thrown consistently.

I believe this was a source of the occasional `unsafe_write` requires `iswritable(::SSLContext)` error where it was actually just a data race between the first `Base.check_open` and the second `isopen` in `iswritable`.