### PR TITLE
Update readme badges and bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MbedTLS"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.1.5"
+version = "1.1.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MbedTLS
 
-[![Build Status](https://travis-ci.org/JuliaLang/MbedTLS.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/MbedTLS.jl)
+[![CI](https://github.com/JuliaLang/MbedTLS.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaLang/MbedTLS.jl/actions/workflows/ci.yml)
 [![codecov.io](https://codecov.io/github/JuliaLang/MbedTLS.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaWeb/MbedTLS.jl?branch=master)
-[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/M/MbedTLS.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
+[![pkgeval](https://juliahub.com/docs/MbedTLS/pkgeval.svg)](https://juliahub.com/ui/Packages/MbedTLS/bf9T0)
 
 A wrapper around the [mbed](https://tls.mbed.org/) TLS and cryptography C libary.
 


### PR DESCRIPTION
The README's CI badge still points to Travis and PkgEval badges now come from JuliaHub. I've also bumped the version after #257.