### PR TITLE
Use Base.IOError in closewrite

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -15,6 +15,7 @@ function show(io::IO, err::MbedException)
 end
 
 mbed_err(ret) = throw(MbedException(ret))
+mbed_ioerr(ret) = throw(Base.IOError(strerror(ret), ret))
 
 function strerror(ret, bufsize=1000)
     buf = Vector{UInt8}(undef, bufsize)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -361,6 +361,7 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
                 ctx.bytesavailable = 0                                          ;@😬 "ssl_read ⌛️ $nread"
                 return nread
             elseif n < 0
+                ssl_abandon(ctx)
                 mbed_ioerr(n)
             end
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -78,7 +78,7 @@ function handshake(ctx::SSLContext)
             end
         else
             ssl_abandon(ctx)                                                    ;@💀 "🤝  💥"
-            throw(Base.IOError(strerror(n), n))
+            mbed_ioerr(n)
         end
     end
                                                                                 ;@😬 "🤝  ✅"
@@ -108,7 +108,7 @@ function ssl_abandon(ctx::SSLContext)                                           
     ctx.close_notify_sent = true
     close(ctx.bio)
     n = ssl_session_reset(ctx)
-    n == 0 || throw(Base.IOError(strerror(n), n))
+    n == 0 || mbed_ioerr(n)
     nothing
 end
 
@@ -202,7 +202,7 @@ function closewrite(ctx::SSLContext)                                            
                       "never returns ...WANT_READ/WRITE."
     elseif n != 0
         ssl_abandon(ctx)
-        throw(Base.IOError(strerror(n), n))
+        mbed_ioerr(n)
     elseif !ctx.isreadable
         # already seen EOF, so we can go ahead and destroy this now immediately
         close(ctx.bio)
@@ -234,7 +234,7 @@ function ssl_unsafe_write(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
             continue
         elseif n < 0
             ssl_abandon(ctx)                                                    ;@🤖 "ssl_write 💥"
-            throw(Base.IOError(strerror(n), n))
+            mbed_ioerr(n)
         end
         nwritten += n
     end
@@ -361,7 +361,7 @@ function ssl_unsafe_read(ctx::SSLContext, buf::Ptr{UInt8}, nbytes::UInt)
                 ctx.bytesavailable = 0                                          ;@😬 "ssl_read ⌛️ $nread"
                 return nread
             elseif n < 0
-                throw(Base.IOError(strerror(n), n))
+                mbed_ioerr(n)
             end
 
             nread += n

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -326,7 +326,7 @@ When TLS `close_notify` is received:
    [RFC5246 7.2.1]: "Any data received after a closure alert is ignored."
  - the number of bytes read before the `close_notify` is returned as usual.
 
-Throws a `MbedException` if `ssl_read` returns an unhandled error code.
+Throws a `IOError` if `ssl_read` returns an unhandled error code.
 
 When an unhandled exception occurs `isreadable` is set to false.
 """

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -78,7 +78,7 @@ function handshake(ctx::SSLContext)
             end
         else
             ssl_abandon(ctx)                                                    ;@💀 "🤝  💥"
-            throw(MbedException(n))
+            throw(Base.IOError(strerror(n), n))
         end
     end
                                                                                 ;@😬 "🤝  ✅"
@@ -108,7 +108,7 @@ function ssl_abandon(ctx::SSLContext)                                           
     ctx.close_notify_sent = true
     close(ctx.bio)
     n = ssl_session_reset(ctx)
-    n == 0 || throw(MbedException(n))
+    n == 0 || throw(Base.IOError(strerror(n), n))
     nothing
 end
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -202,7 +202,7 @@ function closewrite(ctx::SSLContext)                                            
                       "never returns ...WANT_READ/WRITE."
     elseif n != 0
         ssl_abandon(ctx)
-        throw(MbedException(n))
+        throw(Base.IOError(strerror(n), n))
     elseif !ctx.isreadable
         # already seen EOF, so we can go ahead and destroy this now immediately
         close(ctx.bio)


### PR DESCRIPTION
Instead of MbedException, in line with #257

Fixes #259