### PR TITLE
remove unsafe pointer calls

### DIFF
--- a/src/cipher.jl
+++ b/src/cipher.jl
@@ -199,8 +199,8 @@ function set_key!(cipher::Cipher, key, op::Operation)
     key_b = tobytes(key)
     keysize = 8 * sizeof(key_b)  # Convert key size from bytes to bits
     @err_check ccall((:mbedtls_cipher_setkey, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Cint),
-        cipher.data, pointer(key_b), keysize, Int(op))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint),
+        cipher.data, key_b, keysize, Int(op))
     key
 end
 
@@ -212,8 +212,8 @@ end
 function set_iv!(cipher::Cipher, iv)
     iv_b = tobytes(iv)
     @err_check ccall((:mbedtls_cipher_set_iv, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-        cipher.data, pointer(iv_b), sizeof(iv_b))
+        (Ptr{Cvoid}, Ptr{UInt8}, Csize_t),
+        cipher.data, iv_b, sizeof(iv_b))
 end
 
 """
@@ -263,7 +263,7 @@ function crypt!(cipher::Cipher, iv, buf_in, buf_out)
     iv_b, iv_size = process_iv(iv, cipher)
     buf_in_b = tobytes(buf_in)
     @err_check ccall((:mbedtls_cipher_crypt, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Ptr{Csize_t}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Ptr{UInt8}, Ptr{Csize_t}),
         cipher.data, iv_b, iv_size, buf_in_b, sizeof(buf_in_b),
         buf_out, olen_ref)
     Int(olen_ref[])

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -46,5 +46,5 @@ end
 
 function update_manual(ctx::Entropy, data::Vector{UInt8})
     @err_check ccall((:mbedtls_entropy_update_manual, libmbedcrypto), Cint,
-      (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), ctx.data, pointer(data), length(data))
+      (Ptr{Cvoid}, Ptr{UInt8}, Csize_t), ctx.data, data, length(data))
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -18,11 +18,12 @@ mbed_err(ret) = throw(MbedException(ret))
 mbed_ioerr(ret) = throw(Base.IOError(strerror(ret), ret))
 
 function strerror(ret, bufsize=1000)
-    buf = Vector{UInt8}(undef, bufsize)
+    buf = Base.StringVector(bufsize)
     ccall((:mbedtls_strerror, libmbedcrypto), Cint,
         (Cint, Ptr{Cvoid}, Csize_t),
         ret, buf, bufsize)
-    s = GC.@preserve buf unsafe_string(pointer(buf))
+    resize!(buf, something(findfirst(0x00, buf), length(buf) + 1) - 1)
+    s = String(buf)
     if ret == MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE
         s *= " (You may need to enable `ssl_conf_renegotiation!`. See " *
         "https://github.com/JuliaWeb/HTTP.jl/issues/342#issuecomment-432921180)"

--- a/src/md.jl
+++ b/src/md.jl
@@ -84,8 +84,8 @@ function MD(kind::MDKind, key)
         (Ptr{Cvoid}, Ptr{Cvoid}, Cint),
         ctx.data, ctx.info.data, 1)
     @err_check ccall((:mbedtls_md_hmac_starts, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-        ctx.data, pointer(key), sizeof(key))
+        (Ptr{Cvoid}, Ptr{UInt8}, Csize_t),
+        ctx.data, key, sizeof(key))
     ctx
 end
 
@@ -145,14 +145,14 @@ Base.write(ctx::MD, i::Int8) = _write(ctx, Ref(i), sizeof(i))
 
 function finish!(ctx::MD{false}, buf)
     @err_check ccall((:mbedtls_md_finish, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}),
-        ctx.data, pointer(buf))
+        (Ptr{Cvoid}, Ptr{UInt8}),
+        ctx.data, buf)
 end
 
 function finish!(ctx::MD{true}, buf)
     @err_check ccall((:mbedtls_md_hmac_finish, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}),
-        ctx.data, pointer(buf))
+        (Ptr{Cvoid}, Ptr{UInt8}),
+        ctx.data, buf)
 end
 
 function finish!(ctx::MD)
@@ -169,8 +169,8 @@ end
 
 function digest!(kind::MDKind, msg, buf)
     @err_check ccall((:mbedtls_md, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Ptr{Cvoid}),
-        MDInfo(kind).data, pointer(msg), sizeof(msg), pointer(buf))
+        (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{UInt8}),
+        MDInfo(kind).data, msg, sizeof(msg), buf)
 end
 
 """
@@ -201,9 +201,9 @@ end
 
 function digest!(kind::MDKind, msg, key, buf)
     @err_check ccall((:mbedtls_md_hmac, libmbedcrypto), Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Ptr{Cvoid}, Csize_t, Ptr{Cvoid}),
-        MDInfo(kind).data, pointer(key), sizeof(key),
-        pointer(msg), sizeof(msg), pointer(buf))
+        (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Ptr{UInt8}),
+        MDInfo(kind).data, key, sizeof(key),
+        msg, sizeof(msg), buf)
 end
 
 function digest(kind::MDKind, msg, key)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -456,7 +456,7 @@ function Base.readbytes!(ctx::SSLContext, buf::Vector{UInt8}, nbytes::UInt;
                          all::Bool=true)
     nbytes <= length(buf) || throw(ArgumentError("`buf` too small!"))
     nread = 0
-    while nread < nbytes
+    GC.@preserve buf while nread < nbytes
         nread += ssl_unsafe_read(ctx, pointer(buf) + nread, nbytes - nread)
         if (nread == nbytes) || !all || eof(ctx)
             break
@@ -477,7 +477,7 @@ The amount of decrypted data that can be read at once is limited by
 function Base.readavailable(ctx::SSLContext)
     n = UInt(MBEDTLS_SSL_MAX_CONTENT_LEN)
     buf = Vector{UInt8}(undef, n)
-    n = ssl_unsafe_read(ctx, pointer(buf), n)                                   ;@😬 "readavailable ⬅️  $n"
+    GC.@preserve buf n = ssl_unsafe_read(ctx, pointer(buf), n)                  ;@😬 "readavailable ⬅️  $n"
     return resize!(buf, n)
 end
 

--- a/src/x509_crt.jl
+++ b/src/x509_crt.jl
@@ -16,11 +16,13 @@ end
 show(io::IO, crt::CRT) = print(io, crt_info(crt))
 
 function crt_info(crt::CRT)
-    buf = zeros(UInt8, 1000)
-    ccall((:mbedtls_x509_crt_info, libmbedx509), Cint,
+    buf = Base.StringVector(1000)
+    ret = ccall((:mbedtls_x509_crt_info, libmbedx509), Cint,
         (Ptr{Cvoid}, Csize_t, Cstring, Ptr{Cvoid}),
-        buf, 1000, "", crt.data)
-    GC.@preserve buf unsafe_string(pointer(buf))
+        buf, length(buf), "", crt.data)
+    ret >= 0 || mbed_err(ret)
+    resize!(buf, ret)
+    return String(buf)
 end
 
 function crt_parse!(chain, buf::String)


### PR DESCRIPTION
Almost entirely unneeded, and entirely unsafe, except for the failure to specify the ccall API correctly.