### PR TITLE
Revert "Bump version"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MbedTLS"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.1.8"
+version = "1.1.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
This reverts commit 66a3632a85ddbc953c5ea6f384d80e02f04b747d. We didn't tag the release before https://github.com/JuliaLang/MbedTLS.jl/pull/267 landed, so reverting this and then reapplying it to avoid skipping a version.