### PR TITLE
Update TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,28 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
The TagBot workflow was disabled as there was no activity in this repo for 60 days. When I enabled it, it [failed](https://github.com/JuliaLang/MbedTLS.jl/actions/runs/6802831333/job/18496794883#step:3:51) with a permissions problem.

This PR will (hopefully) fix both problems:
- Stop using cron and use an issue comment trigger as suggested in: https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249
- Also update permissions as suggested in (:
https://discourse.julialang.org/t/slow-tagbot-no-repo-update-after-16-hours/80870/17

This now matches the [example TagBot YAML](https://github.com/JuliaRegistries/TagBot/blob/master/example.yml).