### PR TITLE
remove non-existent ssh key from TagBot.yml

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,4 +28,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This means pushing a new tag won't build docs for it, but we don't have that in CI anyways.